### PR TITLE
Initialize internal buffer pointer to NULL

### DIFF
--- a/src/imagemanager/UnstitchedVolume.cpp
+++ b/src/imagemanager/UnstitchedVolume.cpp
@@ -544,7 +544,7 @@ real32* UnstitchedVolume::internal_loadSubvolume_to_real32(int &VV0,int &VV1, in
 	D0 = stitcher->D0;
 	D1 = stitcher->D1;
 
-	iom::real_t* buffer;								//buffer temporary image data are stored
+	iom::real_t* buffer = NULL; //buffer temporary image data are stored
 
 	if ( !cb->getSubvolume(current_channel,V0,V1,H0,H1,D0,D1,buffer) ) {
 


### PR DESCRIPTION
It is good practice to initialize pointers (to NULL, if nothing else).  There seems to be a code path where this pointer could be returned to the user with the intention to have it deallocated, though I admit I do not follow all the code's logic well enough to know if this would happen in practice.  

In examining the code, this line seemed like a candidate to solve the problem in #83 - and it seems to have, at least in my application.

I am aware that memory issues are hard to diagnose, and simply recompiling with this change could have moved the issue elsewhere (where my application does not tickle it).  So I am not certain this is 100% a fix.