### PR TITLE
Use active channel displacements for multi-volume

### DIFF
--- a/src/volumemanager/vmMCVolume.h
+++ b/src/volumemanager/vmMCVolume.h
@@ -109,7 +109,9 @@ class vm::MCVolume : public vm::VirtualVolume
 		std::string getACTIVE_TP  ( ) { return active_tp; }
 		void        setACTIVE_TP  (int t) { active_tp = t; }
 
-		int         getN_ROWS() { return subvolumes[active_channel]->getN_ROWS(); }
+		float       getMEC_H() { return subvolumes[active_channel]->getMEC_H(); }
+  		float       getMEC_V() { return subvolumes[active_channel]->getMEC_V(); }
+  		int         getN_ROWS() { return subvolumes[active_channel]->getN_ROWS(); }
 		int	        getN_COLS() { return subvolumes[active_channel]->getN_COLS(); }
 		int         getN_SLICES() { return subvolumes[active_channel]->getN_SLICES(); }
 		int	        getOVERLAP_V() { return subvolumes[active_channel]->getOVERLAP_V(); }

--- a/src/volumemanager/vmVirtualVolume.cpp
+++ b/src/volumemanager/vmVirtualVolume.cpp
@@ -71,10 +71,10 @@ int		VirtualVolume::getN_SLICES()				{return this->N_SLICES;}
 int		VirtualVolume::getDIM_C()					{return this->DIM_C;}
 int		VirtualVolume::getBYTESxCHAN()				{return this->BYTESxCHAN;}
 //char*   VirtualVolume::getSTACKS_DIR()				{return this->stacks_dir;}
-int		VirtualVolume::getOVERLAP_V()				{return (int)(getStacksHeight() - MEC_V/VXL_V);}
-int		VirtualVolume::getOVERLAP_H()				{return (int)(getStacksWidth() -  MEC_H/VXL_H);}
-int		VirtualVolume::getDEFAULT_DISPLACEMENT_V()	{return (int)(fabs(MEC_V/VXL_V));}
-int		VirtualVolume::getDEFAULT_DISPLACEMENT_H()	{return (int)(fabs(MEC_H/VXL_H));}
+int		VirtualVolume::getOVERLAP_V()				{return (int)(getStacksHeight() - getMEC_V()/getVXL_V());}
+int		VirtualVolume::getOVERLAP_H()				{return (int)(getStacksWidth() -  getMEC_H()/getVXL_H());}
+int		VirtualVolume::getDEFAULT_DISPLACEMENT_V()	{return (int)(fabs(getMEC_V()/getVXL_V()));}
+int		VirtualVolume::getDEFAULT_DISPLACEMENT_H()	{return (int)(fabs(getMEC_H()/getVXL_H()));}
 int		VirtualVolume::getDEFAULT_DISPLACEMENT_D()	{return 0;}
 
 VirtualVolume::~VirtualVolume() {

--- a/src/volumemanager/vmVirtualVolume.h
+++ b/src/volumemanager/vmVirtualVolume.h
@@ -147,8 +147,8 @@ class volumemanager::VirtualVolume
 		float	 getVXL_V();
 		float	 getVXL_H();
 		float	 getVXL_D();
-		float	 getMEC_V();
-		float	 getMEC_H();
+		virtual float getMEC_V();
+		virtual float getMEC_H();
 		virtual int getStacksHeight() = 0;
 		virtual int	getStacksWidth() = 0;
 		virtual int getN_ROWS();


### PR DESCRIPTION
During stitching of a MC volume, the mechanical displacements of the underlying subvolumes were not being used. The [tile_offset](https://github.com/abria/TeraStitcher/blob/5f17f98e9060e8dd8b6971195fabb7f774c04d84/src/imagemanager/UnstitchedVolume.cpp#L449) was incorrectly computed using -1 ([set here](https://github.com/abria/TeraStitcher/blob/93208de780dce6ddf447d799f6ec24c69aeeaf2a/src/volumemanager/vmMCVolume.cpp#L107)) as the MEC_{H,V} for MultiVolumes.

